### PR TITLE
Multi component publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,15 @@ end
 ```
 
 ```ruby
+aptly_publish "myrepo" do
+  action :create
+  source ['myrepo-main', 'myrepo-contrib']
+  type "repo"
+  prefix "foo"
+end
+```
+
+```ruby
 aptly_publish "pulledpork" do
   action :create
   type "snapshot"

--- a/providers/publish.rb
+++ b/providers/publish.rb
@@ -32,7 +32,7 @@ action :create do
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env
-    not_if %{ aptly publish list | grep ^#{new_resource.name}$ }
+    not_if %{ aptly publish list | grep #{new_resource.name} }
   end
 end
 
@@ -50,7 +50,7 @@ action :drop do
     command "aptly publish drop #{new_resource.name} #{new_resource.prefix}"
     user node['aptly']['user']
     group node['aptly']['group']
-    only_if %{ aptly publish list | grep ^#{new_resource.name}$ }
+    only_if %{ aptly publish list | grep #{new_resource.name} }
     environment aptly_env
   end
 end

--- a/providers/publish.rb
+++ b/providers/publish.rb
@@ -24,8 +24,11 @@ def whyrun_supported?
 end
 
 action :create do
+  sources = Array[new_resource.source].compact.flatten
+  sources << new_resource.name if sources.empty?
+  components = sources.map { |e| '' }.join ','
   execute "Publish #{new_resource.type} - #{new_resource.name}" do
-    command "aptly publish #{new_resource.type} #{new_resource.name} #{new_resource.prefix}"
+    command "aptly publish #{new_resource.type} --components '#{components}' #{sources.join ' '} #{new_resource.prefix}"
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env

--- a/providers/publish.rb
+++ b/providers/publish.rb
@@ -28,7 +28,7 @@ action :create do
   sources << new_resource.name if sources.empty?
   components = sources.map { |e| '' }.join ','
   execute "Publish #{new_resource.type} - #{new_resource.name}" do
-    command "aptly publish #{new_resource.type} --components '#{components}' #{sources.join ' '} #{new_resource.prefix}"
+    command "aptly publish #{new_resource.type} --component '#{components}' #{sources.join ' '} #{new_resource.prefix}"
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env

--- a/resources/publish.rb
+++ b/resources/publish.rb
@@ -27,6 +27,7 @@ def initialize(*args)
 end
 
 attribute :name, :kind_of => String, :name_attribute => true
+attribute :source, :kind_of => [Array, String], :default => nil
 attribute :type, :kind_of => String, :default => nil
 attribute :prefix, :kind_of => String, :default => nil
 attribute :distribution, :kind_of => String, :default => nil


### PR DESCRIPTION
A new `source` parameter could be added to the `aptly_publish` resource to easily add support for multi-component-publishing (described [here](http://www.aptly.info/doc/feature/multi-component/)). I find it rather useful to manage my repositories.

I added to this PR a slight modification of the regexes used to detect already published repos/snapshots, as the previous version didn't work well with the latest aptly.