### PR TITLE
Switch option for aptly_publish

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -61,6 +61,10 @@ if defined?(ChefSpec)
     ChefSpec::Matchers::ResourceMatcher.new(:aptly_publish, :drop, resource_name)
   end
 
+  def switch_aptly_publish(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:aptly_publish, :switch, resource_name)
+  end
+
   # Db commands
   def cleanup_aptly_db(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:aptly_db, :cleanup, resource_name)

--- a/providers/publish.rb
+++ b/providers/publish.rb
@@ -54,3 +54,17 @@ action :drop do
     environment aptly_env
   end
 end
+
+action :switch do
+  execute "Switching #{new_resource.name} to #{new_resource.snapshot}" do
+    command "aptly publish switch #{new_resource.name} #{new_resource.prefix} #{new_resource.snapshot}"
+    user node['aptly']['user']
+    group node['aptly']['group']
+    if new_resource.prefix
+      only_if %( aptly publish list | grep "* #{new_resource.prefix}/#{new_resource.name}" | grep -v #{new_resource.snapshot})
+    else
+      only_if %( aptly publish list | grep "* ./#{new_resource.name}" | grep -v #{new_resource.snapshot})
+    end
+    environment aptly_env
+  end
+end

--- a/providers/publish.rb
+++ b/providers/publish.rb
@@ -28,7 +28,7 @@ action :create do
   sources << new_resource.name if sources.empty?
   components = sources.map { |e| '' }.join ','
   execute "Publish #{new_resource.type} - #{new_resource.name}" do
-    command "aptly publish #{new_resource.type} --component '#{components}' #{sources.join ' '} #{new_resource.prefix}"
+    command "aptly publish #{new_resource.type} --component '#{components}' --distribution '#{distribution}' #{sources.join ' '} #{new_resource.prefix}"
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env

--- a/resources/publish.rb
+++ b/resources/publish.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-actions :create, :update, :drop
+actions :create, :update, :drop, :switch
 default_action :create if defined?(default_action)
 
 # Needed for Chef versions < 0.10.10
@@ -31,4 +31,4 @@ attribute :source, :kind_of => [Array, String], :default => nil
 attribute :type, :kind_of => String, :default => nil
 attribute :prefix, :kind_of => String, :default => nil
 attribute :distribution, :kind_of => String, :default => nil
-
+attribute :snapshot, :kind_of => String, :default => nil


### PR DESCRIPTION
- added switch option to publish provider
- added chefspec for new provider action

tested in kitchen environment with a small remote repo. only switches, if the prefix and name match and the snapshot is not currently used for this publication.