### PR TITLE
install: Fix idempotency (do not execute chmod -R on every runs…)

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -105,4 +105,5 @@ end
 
 execute "aptly db ownership" do
   command "chown -R #{node['aptly']['user']}:#{node['aptly']['group']} #{node['aptly']['rootdir']}/db"
+  not_if { Etc.getpwuid(File.stat("#{node['aptly']['rootdir']}/db/CURRENT").uid).name == node['aptly']['user'] }
 end


### PR DESCRIPTION
This fix the idempotency (and run only chmod command if /opt/aptly/db/CURRENT is not owned by aptly user)

```
* execute[aptly db ownership]
  - execute chown -R aptly:aptly /opt/aptly/db
```