### PR TITLE
Enabling the configuration of the publishing endpoints

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,3 +19,5 @@ default['aptly']['gpgdisableverify'] = false
 default['aptly']['downloadsourcepackages'] = false
 default['aptly']['ppadistributorid'] = ""
 default['aptly']['ppacodename'] = ""
+default['aptly']['s3publishendpoints'] = {}
+default['aptly']['swiftpublishendpoints'] = {}

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -83,7 +83,9 @@ template '/etc/aptly.conf' do
     :gpgdisableverify => node['aptly']['gpgdisableverify'],
     :downloadsourcepackages => node['aptly']['downloadsourcepackages'],
     :ppadistributorid => node['aptly']['ppadistributorid'],
-    :ppacodename => node['aptly']['ppacodename']
+    :ppacodename => node['aptly']['ppacodename'],
+    :s3publishendpoints => node['aptly']['s3publishendpoints'],
+    :swiftpublishendpoints => node['aptly']['swiftpublishendpoints']
   })
 end
 

--- a/templates/default/aptly.conf.erb
+++ b/templates/default/aptly.conf.erb
@@ -1,14 +1,20 @@
-{
-  "rootDir": "<%= @rootdir %>",
-  "downloadConcurrency": <%= @downloadconcurrency %>,
-  "architectures": <%= @architectures %>,
-  "dependencyFollowSuggests": <%= @dependencyfollowsuggests %>,
-  "dependencyFollowRecommends": <%= @dependencyfollowrecommends %>,
-  "dependencyFollowAllVariants": <%= @dependencyfollowallvariants %>,
-  "dependencyFollowSource": <%= @dependencyfollowsource %>,
-  "gpgDisableSign": <%= @gpgdisablesign %>,
-  "gpgDisableVerify": <%= @gpgdisableverify %>,
-  "downloadSourcePackages": <%= @downloadsourcepackages %>,
-  "ppaDistributorID": "<%= @ppadistributorid %>",
-  "ppaCodename": "<%= @ppacodename %>"
+<%=
+config = {
+  "rootDir": @rootdir.to_s,
+  "downloadConcurrency": @downloadconcurrency,
+  "architectures": @architectures,
+  "dependencyFollowSuggests": @dependencyfollowsuggests,
+  "dependencyFollowRecommends": @dependencyfollowrecommends,
+  "dependencyFollowAllVariants": @dependencyfollowallvariants,
+  "dependencyFollowSource": @dependencyfollowsource,
+  "gpgDisableSign": @gpgdisablesign,
+  "gpgDisableVerify": @gpgdisableverify,
+  "downloadSourcePackages": @downloadsourcepackages,
+  "ppaDistributorID": @ppadistributorid.to_s,
+  "ppaCodename": @ppacodename.to_s,
+  "S3PublishEndpoints": @s3publishendpoints,
+  "SwiftPublishEndpoints": @swiftpublishendpoints
 }
+
+JSON.pretty_generate(JSON.parse(config.to_json))
+%>


### PR DESCRIPTION
Aptly now has the ability to publish to S3 and Swift.
https://www.aptly.info/doc/configuration/

So I have updated the attributes, template, and recipe to allow one to configure those with the cookbook.

Thanks.